### PR TITLE
fix(memory_delete): accept the numeric id its own MCP schema declares

### DIFF
--- a/src/codex-bridge-extra-memory-ops.ts
+++ b/src/codex-bridge-extra-memory-ops.ts
@@ -12,8 +12,17 @@ export async function memoryTranscriptOp(memoryManager: CodexBridgeExtraDeps['me
   return { sessionId: sid, count: memories.filter((m) => m.sessionId === sid && (role === 'all' || (m.metadata?.role as string | undefined) === role)).length, transcript: memories };
 }
 
+// `memory_delete`'s MCP schema declares `id` as a number, but this called
+// requireString() -- so any schema-validating client (e.g. Claude Code) could
+// never invoke the tool. Accept either form and validate it is a real id.
+function requireMemoryId(value: unknown): number {
+  const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value.trim()) : NaN;
+  if (!Number.isInteger(n) || n <= 0) throw new Error('id must be a positive integer memory id.');
+  return n;
+}
+
 export async function memoryDeleteOp(memoryManager: CodexBridgeExtraDeps['memoryManager'], id: unknown) {
-  return { deleted: await memoryManager.deleteMemory(Number(requireString(id, 'id'))) };
+  return { deleted: await memoryManager.deleteMemory(requireMemoryId(id)) };
 }
 
 export async function memoryContextOp(deps: CodexBridgeExtraDeps, sessionId: string | undefined, input: Record<string, unknown>) {


### PR DESCRIPTION
## Problem

`memory_delete` advertises its `id` argument as a **number** in its tool schema (`src/codex-mcp-extra-tools.ts`):

```ts
id: { type: 'number', description: 'Memory ID to delete.' },
```

but `memoryDeleteOp` validated it as a **string**, only to immediately coerce it back:

```ts
return { deleted: await memoryManager.deleteMemory(Number(requireString(id, 'id'))) };
```

Any MCP client that validates outgoing arguments against the declared schema therefore sends a number and receives:

```
MCP error -32602: id must be a non-empty string.
```

The tool is effectively **uncallable** from such a client — Claude Code hits this on every invocation. Clients that don't enforce the declared type happen to send strings, which is why it went unnoticed.

## Fix

The schema is correct; the validator was wrong. `requireMemoryId` accepts either form and validates that the result is a positive integer.

## Behaviour

| call | before | after |
|---|---|---|
| `memory_delete {"id": 999999}` | `-32602 id must be a non-empty string` | `{"deleted": false}` |
| `memory_delete {"id": "999999"}` | `{"deleted": false}` | `{"deleted": false}` (back-compat) |
| `memory_delete {"id": "abc"}` | `{"deleted": false}` (silently `NaN`) | `id must be a positive integer memory id.` |

Note the third row: the old code passed `Number("abc")` → `NaN` straight into `deleteMemory`. The new helper rejects it.

`requireString` remains imported and in use elsewhere in the file.

## Verification

Applied and exercised against a live Postgres-backed CSM instance; `tsc --noEmit` clean. Uses a non-existent id, so nothing is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
