### PR TITLE
fix(concept-extractor): stop capturing prose paragraphs as memory tags

### DIFF
--- a/src/concept-extractor.ts
+++ b/src/concept-extractor.ts
@@ -17,9 +17,16 @@ export type ExtractionResult = {
 
 const FILE_PATH_REGEX = /(?:src|lib|test|app)\/[a-zA-Z0-9_\-./]+\.(ts|js|tsx|jsx|py|rs|go|java|cs|php|rb|swift|kt|scala|clj|ex|erl|hs|ml|fs|vim|sql|json|yaml|yml|toml|ini|cfg|conf|md|txt)/g;
 const FUNCTION_REGEX = /\b(?:function|const|let|var|async\s+function|export\s+(?:async\s+)?function|export\s+const)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/g;
-const ERROR_REGEX = /(?:Error|Exception|Fail|Failed|panic|crash|traceback|stack trace)[:\s]+([^\n]{10,200})/gi;
+// Require an explicit ':' or '=' delimiter so ordinary prose ("...that error is
+// swallowed...") no longer matches, and cap the capture at tag-sized length.
+const ERROR_REGEX = /(?:Error|Exception|Failed?|panic|crash|traceback|stack trace)\s*[:=]\s*([^\n]{10,120})/gi;
 const DECISION_KEYWORDS = ["decided", "decision", "chose", "selected", "picked", "will use", "going to use", "switching to", "migrating to", "adopted", "replaced with"];
 const TOOL_PATTERNS = ["memory_search", "memory_save", "memory_recall", "context_compact", "checkpoint_create", "checkpoint_list", "auto_docs", "csm_memory_search", "csm_memory_save", "csm_memory_list", "csm_memory_context", "csm_memory_lesson", "csm_memory_transcript", "csm_memory_distill", "csm_memory_distilled_view", "csm_memory_compact"];
+
+/** Concept values are reused as memory tags; keep them tag-sized. */
+const MAX_CONCEPT_VALUE = 80;
+const clampConcept = (s: string): string =>
+  s.length <= MAX_CONCEPT_VALUE ? s : `${s.slice(0, MAX_CONCEPT_VALUE - 3).trimEnd()}...`;
 
 export function extractConcepts(text: string, _sessionId?: string): ExtractionResult {
   const concepts: ExtractedConcept[] = [];
@@ -58,7 +65,7 @@ export function extractConcepts(text: string, _sessionId?: string): ExtractionRe
   // Extract error messages
   const errorMessages: string[] = [];
   while ((match = ERROR_REGEX.exec(text)) !== null) {
-    const err = match[1].trim();
+    const err = clampConcept(match[1].trim());
     if (!errorMessages.includes(err)) {
       errorMessages.push(err);
       concepts.push({
@@ -73,9 +80,11 @@ export function extractConcepts(text: string, _sessionId?: string): ExtractionRe
   // Extract decisions
   const decisions: string[] = [];
   for (const keyword of DECISION_KEYWORDS) {
-    const regex = new RegExp(`\\b${keyword}\\b[^.]*\\.`, "gi");
+    // Stop at a newline and cap the span so a period-less sentence cannot
+    // swallow an entire paragraph.
+    const regex = new RegExp(`\\b${keyword}\\b[^.\\n]{0,120}\\.`, "gi");
     while ((match = regex.exec(text)) !== null) {
-      const decision = match[0].trim();
+      const decision = clampConcept(match[0].trim());
       if (!decisions.includes(decision)) {
         decisions.push(decision);
         concepts.push({


### PR DESCRIPTION
## Problem

Extracted concept values are reused as **memory tags**, so an unbounded capture pollutes the shared tag vocabulary. Two extractors capture unbounded spans of prose.

**1. `ERROR_REGEX` matches ordinary English.**

```ts
const ERROR_REGEX = /(?:Error|Exception|Fail|Failed|panic|crash|traceback|stack trace)[:\s]+([^\n]{10,200})/gi;
```

The `[:\s]+` permits a plain **space**, so a normal sentence matches:

> "...if that **error is** swallowed, the variable comes back `$null`..."

and up to 200 characters become a tag.

**2. The decision regex has no length bound.**

```ts
const regex = new RegExp(`\\b${keyword}\\b[^.]*\\.`, "gi");
```

It runs from the keyword to the next period, so a sentence lacking a nearby period swallows an entire paragraph.

Observed in a live database as tags **200–246 characters long**.

## Fix

- `ERROR_REGEX` now requires an explicit `:` or `=` delimiter, and caps the capture at 120 chars.
- The decision span stops at a newline and is capped at 120 chars.
- Both pass through `clampConcept`, truncating to `MAX_CONCEPT_VALUE` (80) with an ellipsis.

## Trade-off

A log line with no delimiter (`Error ENOENT ...`) stops matching. Real traces carry a `:`; false negatives are cheaper than paragraph-long tags. Happy to widen the delimiter class if you'd rather keep those.

## Scope

New extractions only — existing rows are untouched. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
