### PR TITLE
fix(provenance): derive it from the clientInfo handshake, and stop callers forging it

### DIFF
--- a/src/bridge-provenance.ts
+++ b/src/bridge-provenance.ts
@@ -18,6 +18,33 @@ export interface BridgeProvenanceSummary {
   gapCount: number;
 }
 
+/**
+ * Identity of the MCP client attached to this process, captured from the
+ * `initialize` handshake. Falls back to the historical Codex defaults when no
+ * client announced itself (e.g. the in-process Codex plugin runtime), so
+ * existing behaviour is preserved.
+ */
+let clientIdentity: { surface?: string; agentId?: string } = {};
+
+/** Cowork announces `local-agent-mode-<serverName>` — a per-connection string,
+ *  not a stable agent identity. Collapse it to one surface. */
+function normalizeSurface(name: string): string {
+  return name.startsWith('local-agent-mode-') ? 'cowork' : name;
+}
+
+export function setClientIdentity(info?: { name?: string; version?: string }): void {
+  const name = info?.name?.trim();
+  if (!name) return;
+  clientIdentity = {
+    surface: normalizeSurface(name),
+    agentId: info?.version ? `${name}@${info.version}` : name,
+  };
+}
+
+export function getClientIdentity(): { surface?: string; agentId?: string } {
+  return { ...clientIdentity };
+}
+
 export function rankMemoriesByProvenance(memories: Memory[]): Memory[] {
   return [...memories].sort(compareMemories);
 }
@@ -52,9 +79,9 @@ export function buildBridgeProvenanceMetadata(
     source_kind: current.source_kind ?? context.sourceKind ?? 'user_supplied',
     evidence_strength: current.evidence_strength ?? 'direct_original',
     source_session_id: current.source_session_id ?? context.sessionId,
-    source_agent_id: current.source_agent_id ?? 'codex-bridge',
-    source_model_id: current.source_model_id ?? 'gpt-5-codex',
-    source_surface: current.source_surface ?? 'codex',
+    source_agent_id: current.source_agent_id ?? clientIdentity.agentId ?? 'codex-bridge',
+    source_model_id: current.source_model_id,
+    source_surface: current.source_surface ?? clientIdentity.surface ?? 'codex',
     project_root: current.project_root ?? context.projectRoot,
     ...current,
   };

--- a/src/codex-bridge-extra-memory-ops.ts
+++ b/src/codex-bridge-extra-memory-ops.ts
@@ -4,6 +4,7 @@ import type { Database } from './database.js';
 import { ToolCallDistiller } from './tool-distiller.js';
 import type { MemoryType, ToolCallRecord } from './types.js';
 import { asLimit, asRecord, asString, asStringArray, requireSession, requireString } from './codex-bridge-extra-utils.js';
+import { withBridgeProvenance } from './bridge-provenance.js';
 
 export async function memoryTranscriptOp(memoryManager: CodexBridgeExtraDeps['memoryManager'], sessionId: string | undefined, input: Record<string, unknown>) {
   const sid = requireSession(sessionId);
@@ -25,10 +26,22 @@ export async function memoryContextOp(deps: CodexBridgeExtraDeps, sessionId: str
   };
 }
 
+/** Caller-supplied `context` must never dictate provenance: strip source_* / evidence keys
+ *  so the MCP clientInfo handshake stays the only authority. */
+function stripProvenanceKeys(meta: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!meta) return meta;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (key.startsWith('source_') || key === 'evidence_strength' || key === 'derivative_of') continue;
+    out[key] = value;
+  }
+  return out;
+}
+
 export async function memoryLessonOp(memoryManager: CodexBridgeExtraDeps['memoryManager'], sessionId: string | undefined, input: Record<string, unknown>) {
   const sid = requireSession(sessionId);
   return {
-    memory: await memoryManager.saveMemory({
+    memory: await memoryManager.saveMemory(withBridgeProvenance({
       content: requireString(input.content, 'content'),
       type: 'lesson',
       importance: 0.75,
@@ -36,9 +49,9 @@ export async function memoryLessonOp(memoryManager: CodexBridgeExtraDeps['memory
       confidence: 0.9,
       source: 'lesson',
       tags: asStringArray(input.tags) ?? ['lesson'],
-      metadata: asRecord(input.context),
+      metadata: stripProvenanceKeys(asRecord(input.context)),
       sessionId: sid,
-    }),
+    }, { sessionId: sid, projectRoot: asString(input.projectRoot) ?? sid, sourceKind: 'user_supplied' })),
   };
 }
 

--- a/src/codex-mcp-server.ts
+++ b/src/codex-mcp-server.ts
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 import { CodexMemoryBridge } from './codex-bridge.js';
 import { invokeMcpTool, MCP_TOOLS } from './codex-mcp-tools.js';
+import { setClientIdentity } from './bridge-provenance.js';
 
 const SERVER_NAME = 'Cross-Session Memory Bridge';
 const SERVER_VERSION = '1.0.0';
@@ -33,8 +34,9 @@ function getBridge(): Promise<CodexMemoryBridge> {
   return bridgePromise;
 }
 
-async function handle(message: { id?: JsonRpcId; method?: string; params?: { name?: string; arguments?: Record<string, unknown>; protocolVersion?: string } }) {
+async function handle(message: { id?: JsonRpcId; method?: string; params?: { name?: string; arguments?: Record<string, unknown>; protocolVersion?: string; clientInfo?: { name?: string; version?: string } } }) {
   if (message.method === 'initialize' && message.id !== undefined) {
+    setClientIdentity(message.params?.clientInfo);
     sendResult(message.id, {
       protocolVersion: message.params?.protocolVersion ?? '2025-11-25',
       capabilities: { tools: {} },
@@ -66,7 +68,7 @@ async function cleanup(): Promise<void> {
 const input = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
 input.on('line', (line) => {
   if (!line.trim()) return;
-  handle(JSON.parse(line) as { id?: JsonRpcId; method?: string; params?: { name?: string; arguments?: Record<string, unknown>; protocolVersion?: string } })
+  handle(JSON.parse(line) as { id?: JsonRpcId; method?: string; params?: { name?: string; arguments?: Record<string, unknown>; protocolVersion?: string; clientInfo?: { name?: string; version?: string } } })
     .catch((error: unknown) => send({ jsonrpc: '2.0', error: { code: -32603, message: String(error) } }));
 });
 


### PR DESCRIPTION
Two related defects mean **"which agent wrote this memory" is wrong for the entire pool**. They compound, so they're fixed together.

## 1. Every client is recorded as Codex

`buildBridgeProvenanceMetadata()` hardcodes Codex defaults:

```ts
source_agent_id: current.source_agent_id ?? 'codex-bridge',
source_model_id: current.source_model_id ?? 'gpt-5-codex',
source_surface:  current.source_surface  ?? 'codex',
```

Every client running this bridge — Claude Code, Claude Desktop, Antigravity — stamps its memories as Codex, with a model id **it never announced**.

In one shared database this produced **55 of 79 rows** claiming `source_model_id='gpt-5-codex'`, with a perfect 1:1 lock to `source_surface='codex'`. Because the value is written whether or not Codex is the caller, it carries **no information at all** — even where it happens to be right, it can't establish anything.

The MCP `initialize` request already carries `params.clientInfo`; `codex-mcp-server.ts` simply ignored it.

- `setClientIdentity()` captures `clientInfo` from the handshake.
- `source_agent_id` → `"<name>@<version>"` (e.g. `claude-code@2.1.202`)
- `source_surface` → the announced name
- `source_model_id` → **omitted rather than fabricated.** The client doesn't announce its model, and a false provenance value is worse than a missing one.
- `normalizeSurface()` collapses the per-connection name Claude Desktop announces — `local-agent-mode-<serverName>`, a different string for every server it connects to — into one stable surface.

Falls back to the previous Codex defaults when no client announces itself, so the in-process plugin runtime is unaffected.

> An env var (e.g. `CSM_SOURCE_SURFACE`) would be the wrong fix: it forces every client's MCP env to differ, and the handshake already carries the answer.

## 2. `memory_lesson` bypasses provenance, and lets callers forge it

`memoryLessonOp()` calls `memoryManager.saveMemory()` **directly**, never going through `withBridgeProvenance()`. So:

- **With no `context`**, memory-manager's `hasProvenance` fallback fires and stamps `source_agent_id='opencode'`, `source_model_id='default'`, `source_surface='opencode'` — whichever client is calling.
- **The tool schema exposes a free-form `context: { type: 'object' }`**, passed through as metadata verbatim and spread *last*, so any caller can set `source_model_id` / `source_surface` / `source_kind` to anything. Fix 1 is bypassed entirely on this path.

`memory_lesson` now routes through `withBridgeProvenance()`, and `stripProvenanceKeys()` removes `source_*` / `evidence_strength` / `derivative_of` from caller-supplied context while leaving other context keys intact. The handshake becomes the only provenance authority.

## Verification

Against a live Postgres+pgvector instance, calling `memory_lesson` with a deliberately poisoned context:

```json
{"content": "...", "context": {"source_surface": "INJECTED", "source_model_id": "INJECTED", "note": "keep me"}}
```

stored metadata:

```
source_surface   = "claude-code"            (not INJECTED, not opencode)
source_agent_id  = "claude-code@2.1.202"
source_model_id  = ABSENT
note             = "keep me"                (non-provenance keys preserved)
```

`tsc --noEmit` clean. Both fixes affect **new writes only**; existing rows keep their recorded values.

## Known remainder

`source_session_id` is still generated with a `codex-` prefix elsewhere in the bridge, so "which session" stays mislabelled even once the surface is right. Cosmetic; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
