### PR TITLE
fix(mcp): structuredContent must be a JSON object, not a bare array

### DIFF
--- a/src/codex-mcp-server.ts
+++ b/src/codex-mcp-server.ts
@@ -22,9 +22,15 @@ function sendError(id: JsonRpcId, message: string): void {
 }
 
 function textResult(payload: unknown) {
+  // MCP requires `structuredContent` to be a JSON object:
+  //   structuredContent?: { [key: string]: unknown }
+  // Several tools return a bare array (list_memories, recall_lessons), which
+  // schema-validating clients reject. Wrap any non-object payload under `result`.
+  const isPlainObject =
+    payload !== null && typeof payload === 'object' && !Array.isArray(payload);
   return {
     content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
-    structuredContent: payload,
+    structuredContent: isPlainObject ? (payload as Record<string, unknown>) : { result: payload },
   };
 }
 


### PR DESCRIPTION
## Problem

MCP defines `structuredContent` on `CallToolResult` as an **object**:

```ts
/**
 * An optional JSON object that represents the structured result of the tool call.
 */
structuredContent?: { [key: string]: unknown };
```
<sub>— [`schema/2025-06-18/schema.ts`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-06-18/schema.ts)</sub>

and the [specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content) states:

> **Structured** content is returned as a JSON object in the `structuredContent` field of a result.

`textResult()` in `src/codex-mcp-server.ts` assigns the payload straight through:

```ts
structuredContent: payload,
```

But several tools return a **bare array**. Both `list_memories` and `recall_lessons` resolve to `Promise<Memory[]>` (`src/codex-bridge.ts`), so the server emits:

```json
"structuredContent": [ { "id": "1", ... }, { "id": "2", ... } ]
```

which is not a valid `CallToolResult`.

This server hand-rolls its JSON-RPC rather than using the MCP SDK, so nothing catches this server-side. It surfaces as a validation failure in the client, and **those two tools become unusable from any client that validates results against the protocol schema.**

## Fix

Wrap any payload that isn't a plain object under a `result` key:

```ts
structuredContent: isPlainObject ? payload : { result: payload }
```

Plain objects pass through untouched, so the common case (`save_memory`, `search_memories`, `memory_delete`, …) is unaffected. `null` and primitives are also wrapped rather than emitted as invalid structured content.

The `content` text block is **unchanged** and still carries the serialized payload verbatim, so any client reading the text sees exactly what it saw before.

## Compatibility

This necessarily changes the `structuredContent` shape for the array-returning tools, from a top-level array to `{ "result": [...] }`. There's no backwards-compatible option — the previous shape was not valid MCP. Declaring an `outputSchema` for those tools would be a sensible follow-up, since the spec says servers **MUST** then conform to it.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
