### PR TITLE
test: align bridge provenance expectation

### DIFF
--- a/test/codex-bridge-workflow.test.ts
+++ b/test/codex-bridge-workflow.test.ts
@@ -127,7 +127,8 @@ describe('Codex bridge workflow tools', () => {
     assert.ok(resumed.lessons[0]?.content.includes('raw command output'));
     assert.equal(resumed.workJournal?.sourceSessionId, 'prior-session');
     assert.match(resumed.workJournal?.nextStepInferred ?? '', /Fix error|Missing direct provenance/);
-    assert.equal(resumed.provenance.governanceEligibleCount >= 1, true);
+    assert.equal(resumed.provenance.governanceEligibleCount, 0);
+    assert.equal(resumed.provenance.contextOnlyCount >= 1, true);
     assert.match(resumed.sessionState?.activeGoal?.description ?? '', /richer continuity packet/);
     assert.match(resumed.recovery?.activeCheckpoint?.summaryExcerpt ?? '', /workflow recovery/);
     assert.match(resumed.recovery?.lastError?.summary ?? '', /latest cached error/);


### PR DESCRIPTION
## What changed

Updates the bridge workflow integration test to reflect the provenance contract introduced by PR #27: when an MCP client does not announce a model, the bridge omits `source_model_id` rather than fabricating one, so the memory is correctly classified as `context_only` instead of `governance_eligible`.

## Root cause

PR #27 intentionally removed the fabricated `gpt-5-codex` model ID. The existing test still asserted the old governance classification, causing final `master` verification to report 917/918 passing.

## Validation

- Focused bridge workflow: 3/3 pass
- `npm run verify`: build + typecheck + 918/918 tests pass
- `npm run lint:src`: 0 errors, locked baseline of 7 warnings