### PR TITLE
fix(redactor): 'normalize' silently redacts every path when no workspaceRoot is set

### DIFF
--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -116,7 +116,13 @@ export class Redactor {
     if (config?.categories) {
       this.config.categories = { ...DEFAULT_REDACTOR_CONFIG.categories, ...config.categories };
     }
-    this.workspaceRoot = this.config.workspaceRoot ?? null;
+    // `path: 'normalize'` is meaningless without a root: normalizePath() falls straight
+    // through to the [REDACTED_PATH] marker for EVERY path when workspaceRoot is unset,
+    // silently turning the default 'normalize' mode into 'redact'. DEFAULT_REDACTOR_CONFIG
+    // ships 'normalize' but no default root, so that is what every caller which never sets
+    // one has been getting. Fall back to the process working directory so the documented
+    // behaviour holds out of the box. Paths outside the root are still redacted, as intended.
+    this.workspaceRoot = this.config.workspaceRoot || process.cwd();
   }
 
   /**

--- a/test/redactor.test.ts
+++ b/test/redactor.test.ts
@@ -182,6 +182,23 @@ describe('Redactor — paths', () => {
     assert.equal(result.text, input);
     assert.equal(result.audit.byCategory.path, 0);
   });
+
+  it('normalizes against the working directory when no workspaceRoot is configured', () => {
+    // Regression: DEFAULT_REDACTOR_CONFIG sets path: 'normalize' but supplies no
+    // workspaceRoot, so normalizePath() returned [REDACTED_PATH] for every path and
+    // 'normalize' silently behaved as 'redact'.
+    const r = new Redactor();
+    const result = r.redact(`Edited ${process.cwd()}/src/foo.ts`);
+    assert.ok(result.text.includes('[WORKSPACE]/src/foo.ts'), `expected [WORKSPACE]/src/foo.ts in: ${result.text}`);
+    assert.ok(!result.text.includes('[REDACTED_PATH]'));
+  });
+
+  it('still redacts paths outside the working directory when no workspaceRoot is configured', () => {
+    const r = new Redactor();
+    const result = r.redact('Config at /home/someone-else/secrets/.env');
+    assert.ok(result.text.includes('[REDACTED_PATH]'));
+    assert.ok(!result.text.includes('someone-else'));
+  });
 });
 
 describe('Redactor — audit metadata', () => {


### PR DESCRIPTION
## Problem

`redactor.ts` states path normalisation as the entire purpose of `'normalize'` mode:

```
 *  - Paths are normalized (not blindly redacted) to preserve coding utility:
 *      C:\Users\Donovan\project\src/foo.ts → [WORKSPACE]/src/foo.ts
```

and `DEFAULT_REDACTOR_CONFIG` duly ships `path: 'normalize'`.

But it supplies **no `workspaceRoot`**, and nothing else ever populates one. `normalizePath()` then does:

```ts
private normalizePath(absPath: string): string {
  if (!this.workspaceRoot) {
    // No workspace root configured — redact to marker
    return MARKERS.path;
  }
```

So for any caller that never sets `workspaceRoot` — **which is the default** — `'normalize'` silently behaves as `'redact'`. Every absolute path in every stored string becomes `[REDACTED_PATH]`. No warning, and no test covered the unset-root case.

## Impact

Observed on a live deployment: **10 of 84 stored memories had their paths destroyed.** Memories written specifically to record *which file* changed read:

> `Codex global rules file [REDACTED_PATH] now includes a Cross-Session Memory section…`

Because redaction runs **before embeddings** as well as before storage, the vectors encode the marker too, and the original text never reaches the database — so it is **not recoverable** after the fact.

## Fix

Fall back to `process.cwd()` when no `workspaceRoot` is configured, so the documented behaviour holds out of the box.

```ts
this.workspaceRoot = this.config.workspaceRoot || process.cwd();
```

## What this deliberately does *not* change

**Paths outside the workspace root are still redacted.** That is existing, tested, intentional behaviour:

- `it('redacts non-workspace paths when normalizing', …)`
- `it('redacts POSIX paths outside workspace', …)`

Both remain untouched and passing. This PR only ensures there *is* a root to normalise against.

## Tests

Adds two regression tests for the previously uncovered unset-root case — one asserting a path under cwd normalises to `[WORKSPACE]/…`, one asserting a path outside cwd is still redacted.

```
test/redactor.test.ts              33 pass, 0 fail
test/redactor-integration.test.ts   9 pass, 0 fail
```

(Note: the suites import from `../dist/`, so they need `npm run build` first.)

## Alternative considered

Warning at construction when `path === 'normalize' && !workspaceRoot`, leaving behaviour unchanged. That surfaces the problem but leaves the default mode useless, and `redactor.ts` has no logger dependency today. Happy to switch if you'd rather not introduce a `process.cwd()` read into the constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
