### PR TITLE
fix(quota): lessons are silently summarised, and the caller is never told

### DIFF
--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -197,6 +197,14 @@ async saveMemory(options: MemorySaveOptions): Promise<Memory> {
 
       // Phase 5 — Apply per-type content quota (compress success/episodic, preserve errors/lessons)
       const quotaResult = applyTypeQuota(contentToProcess, options.type, options.emotion);
+      if (quotaResult.compressed) {
+        // The summary is what gets embedded and stored; the original never reaches the DB.
+        getLogger().warn(
+          `Memory of type '${options.type}' exceeded its quota and was COMPRESSED before embedding `
+          + `and storage: ${quotaResult.originalTokens} -> ${quotaResult.finalTokens} tokens. `
+          + `The original text is NOT recoverable. Use type='lesson' for long durable facts.`,
+        );
+      }
       contentToProcess = quotaResult.content;
       
       // Get project_id from session if available, or use directly-provided projectId

--- a/src/memory-type-quota.ts
+++ b/src/memory-type-quota.ts
@@ -4,11 +4,13 @@ import { estimateTokens } from './token-bucket-analyzer.js';
 export interface TypeQuotaConfig {
   maxTokens: number;
   preserveErrors: boolean;
+  /** Never compress this type, whatever its emotion or content. */
+  preserveAlways?: boolean;
   summaryPrefix: string;
 }
 
 const TYPE_QUOTAS: Record<MemoryType, TypeQuotaConfig> = {
-  lesson:           { maxTokens: 800, preserveErrors: true,  summaryPrefix: '[LESSON]' },
+  lesson:           { maxTokens: 800, preserveErrors: true,  preserveAlways: true, summaryPrefix: '[LESSON]' },
   self_continuity:  { maxTokens: 600, preserveErrors: true,  summaryPrefix: '[CONTINUITY]' },
   procedural:       { maxTokens: 500, preserveErrors: true,  summaryPrefix: '[PROC]' },
   preference:       { maxTokens: 400, preserveErrors: false, summaryPrefix: '[PREF]' },
@@ -30,6 +32,14 @@ export function applyTypeQuota(
   const originalTokens = estimateTokens(content);
 
   if (originalTokens <= quota.maxTokens) {
+    return { content, compressed: false, originalTokens, finalTokens: originalTokens };
+  }
+
+  // `lesson` is the designated home for long durable facts, so it is preserved whatever the
+  // emotion. Without this, a neutral lesson saved through save_memory is silently summarised,
+  // while identical content saved through memory_lesson survives only because that tool stamps
+  // emotion='frustration'. Same type, same content, different rows.
+  if (quota.preserveAlways) {
     return { content, compressed: false, originalTokens, finalTokens: originalTokens };
   }
 

--- a/test/memory-type-quota.test.ts
+++ b/test/memory-type-quota.test.ts
@@ -49,4 +49,33 @@ describe('Memory Type Quota', () => {
     assert.equal(result.compressed, false);
     assert.equal(result.content, '');
   });
+
+  it('preserves a NEUTRAL lesson that is over quota and has no error markers', () => {
+    // Regression: `lesson` was only preserved when emotion === 'frustration' or the text
+    // happened to contain an error word. memory_lesson stamps 'frustration', so it always
+    // survived; save_memory({type:'lesson'}) defaults to 'neutral' and was silently summarised.
+    const long = `${'alpha beta gamma delta '.repeat(400)}`;
+    const result = applyTypeQuota(long, 'lesson');
+    assert.ok(result.originalTokens > 800, `fixture must exceed the 800-token lesson quota, got ${result.originalTokens}`);
+    assert.equal(result.compressed, false);
+    assert.equal(result.content, long);
+    assert.doesNotMatch(result.content, /\[LESSON\]|\[quota-compressed/);
+  });
+
+  it('preserves a neutral lesson identically to a frustration lesson', () => {
+    const long = `${'alpha beta gamma delta '.repeat(400)}`;
+    const neutral = applyTypeQuota(long, 'lesson', 'neutral');
+    const frustrated = applyTypeQuota(long, 'lesson', 'frustration');
+    assert.equal(neutral.content, frustrated.content);
+    assert.equal(neutral.compressed, frustrated.compressed);
+  });
+
+  it('still compresses other types over quota (preserveAlways is scoped to lesson)', () => {
+    const long = `${'alpha beta gamma delta '.repeat(400)}`;
+    for (const type of ['workspace', 'preference', 'episodic'] as const) {
+      const result = applyTypeQuota(long, type);
+      assert.equal(result.compressed, true, `${type} should still compress`);
+      assert.match(result.content, /\[quota-compressed/);
+    }
+  });
 });


### PR DESCRIPTION
Two defects, one cause.

## 1. A lossy rewrite with no signal

`memory-manager.ts`:

```ts
const quotaResult = applyTypeQuota(contentToProcess, options.type, options.emotion);
contentToProcess = quotaResult.content;
```

`compressed`, `originalTokens` and `finalTokens` are computed and then **discarded**. When content exceeds its per-type quota, `applyTypeQuota()` rewrites it into a line-selected summary. **That summary is what gets embedded and stored**, the original never reaches the database, and nothing warns the caller — it's only discoverable afterwards, by noticing the `[quota-compressed]` marker in a row you already saved.

Now it logs at `WARN` with the type and the token delta. `workspace`, `preference` and `episodic` still compress past their caps — loudly.

## 2. The same lesson is stored two different ways

`lesson` has `maxTokens: 800, preserveErrors: true`, and an over-quota lesson is preserved only when:

```ts
emotion === 'frustration' || ERROR_MARKERS.test(content)
```

`memory_lesson` stamps `emotion: 'frustration'`, so a lesson written through **that** tool is always kept verbatim. But `save_memory({ type: 'lesson' })` defaults to `'neutral'` — identical content, over 800 tokens, no error word in it, **silently summarised**.

Meanwhile the comment on that very line in `memory-manager.ts` reads:

```ts
// Phase 5 — Apply per-type content quota (compress success/episodic, preserve errors/lessons)
```

*"preserve … lessons"* is true only by accident of the frustration convention. `lesson` now carries `preserveAlways`, so it is preserved whatever the emotion — it's the designated home for long durable facts.

## What I deliberately did *not* do

Make `memory_lesson` default to `emotion: 'neutral'`. That's the obvious-looking fix and it would be wrong:

- `emotion: 'frustration'` on a lesson is a **five-site convention** — `tools.ts:296`, `hooks/tool-execute.ts:128`, `trace-vault-store.ts:120`, `teacher-trace-seeder.ts:60`, `codex-bridge-extra-memory-ops.ts:57` — and `types.ts:80` documents it: `'frustration' // Negativity bias for lessons`.
- `emotion` feeds **nothing** except `applyTypeQuota()` and the stored column. No effect on retrieval, ranking or pruning.
- So neutralising one of the five writers would deepen the inconsistency, and without `preserveAlways` it would start compressing lessons that are currently preserved.

Emotion semantics are untouched. New writes only; existing rows keep whatever they were stored as.

## Tests

`test/memory-type-quota.test.ts` imports from `../src/`, so it runs without a build.

```
npx tsx --test test/memory-type-quota.test.ts     10 pass, 0 fail
tsc --noEmit                                      clean
```

Three added:
- a **neutral** over-quota lesson with no error markers is preserved verbatim (asserts the fixture actually exceeds 800 tokens, and that no `[LESSON]` / `[quota-compressed]` marker appears)
- a neutral lesson and a frustration lesson produce **identical** output
- `workspace` / `preference` / `episodic` still compress — proving `preserveAlways` is scoped to `lesson`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
