### PR TITLE
fix(agentbook): correct tool events and front-page target

### DIFF
--- a/src/agentbook-tool-event.ts
+++ b/src/agentbook-tool-event.ts
@@ -1,0 +1,88 @@
+import type { AgentBookEventInput, AgentBookEventType } from './agentbook-types.js';
+
+interface ToolEventMetadata {
+  tokenCount?: number;
+  error?: string;
+  exitCode?: number;
+}
+
+export interface AgentBookToolEventInput {
+  projectId: string;
+  sessionId: string | null;
+  tool: string;
+  callId: string;
+  args: Record<string, unknown>;
+  title: string;
+  output: string;
+  metadata: ToolEventMetadata;
+}
+
+const COMMAND_TOOLS = new Set(['bash', 'shell', 'terminal']);
+const FILE_READ_TOOLS = new Set(['read']);
+const FILE_CREATE_TOOLS = new Set(['write']);
+const FILE_MODIFY_TOOLS = new Set(['edit', 'multiedit', 'patch', 'apply_patch']);
+const FILE_DELETE_TOOLS = new Set(['delete', 'delete_file', 'remove_file']);
+
+function classifyToolEvent(tool: string, failed: boolean): AgentBookEventType {
+  if (failed) return 'failed_approach';
+  if (COMMAND_TOOLS.has(tool)) return 'command_run';
+  if (FILE_READ_TOOLS.has(tool)) return 'file_read';
+  if (FILE_CREATE_TOOLS.has(tool)) return 'file_created';
+  if (FILE_MODIFY_TOOLS.has(tool)) return 'file_modified';
+  if (FILE_DELETE_TOOLS.has(tool)) return 'file_deleted';
+  return 'note';
+}
+
+function addPath(paths: string[], value: unknown): void {
+  if (typeof value !== 'string') return;
+  const normalized = value.trim();
+  if (normalized && !paths.includes(normalized)) paths.push(normalized);
+}
+
+function extractFiles(args: Record<string, unknown>): string[] {
+  const files: string[] = [];
+  addPath(files, args.filePath);
+  addPath(files, args.path);
+  addPath(files, args.file);
+
+  for (const key of ['files', 'paths']) {
+    const value = args[key];
+    if (!Array.isArray(value)) continue;
+    for (const entry of value) addPath(files, entry);
+  }
+  return files;
+}
+
+function commandFor(tool: string, args: Record<string, unknown>): string | null {
+  if (!COMMAND_TOOLS.has(tool)) return null;
+  return typeof args.command === 'string' ? args.command : null;
+}
+
+function buildMetadata(input: AgentBookToolEventInput): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {
+    tool: input.tool,
+    callId: input.callId,
+  };
+  if (input.metadata.error) metadata.error = input.metadata.error;
+  if (input.metadata.exitCode !== undefined) metadata.exitCode = input.metadata.exitCode;
+  if (input.metadata.tokenCount !== undefined) metadata.tokenCount = input.metadata.tokenCount;
+  return metadata;
+}
+
+export function buildAgentBookToolEventInput(input: AgentBookToolEventInput): AgentBookEventInput {
+  const tool = input.tool.trim().toLowerCase();
+  const failed = Boolean(input.metadata.error)
+    || (input.metadata.exitCode !== undefined && input.metadata.exitCode !== 0);
+  const detail = input.output.trim() || input.title.trim() || (failed ? 'failed' : 'completed');
+
+  return {
+    projectId: input.projectId,
+    sessionId: input.sessionId,
+    eventType: classifyToolEvent(tool, failed),
+    summary: `${input.tool}: ${detail.slice(0, 200)}`,
+    files: extractFiles(input.args),
+    command: commandFor(tool, input.args),
+    result: failed ? 'error' : 'success',
+    metadata: buildMetadata(input),
+  };
+}

--- a/src/hooks/tool-execute.ts
+++ b/src/hooks/tool-execute.ts
@@ -6,7 +6,7 @@ import { ensureProjectDocsInitialized } from './auto-docs.js';
 import { autoDistill, logToolUsage } from './tool-execute-memory.js';
 import { isReentrySourceOnlyActive, REENTRY_SOURCE_ONLY_RECOVERY_MESSAGE } from './reentry-source-only.js';
 import { getLogger } from '../logger.js';
-import type { AgentBookEventInput } from '../agentbook-types.js';
+import { buildAgentBookToolEventInput } from '../agentbook-tool-event.js';
 import { generateFrontPage, writeFrontPageFile } from '../agentbook-frontpage.js';
 
 
@@ -129,19 +129,16 @@ async function captureAgentBookEvent(
   if (!ctx.agentBookEvents) return;
   try {
     const projectId = (ctx.config as { projectId?: string }).projectId ?? 'cross-session-memory';
-    const toolOutput = summarizeToolOutput(output.output);
-    const eventInput: AgentBookEventInput = {
+    const eventInput = buildAgentBookToolEventInput({
       projectId,
       sessionId: sid,
-      eventType: input.tool === 'bash' || input.tool === 'bash' ? 'command_run' : 'file_modified',
-      summary: `${input.tool}: ${toolOutput.slice(0, 200)}`,
-      command: input.tool === 'bash' ? String((input as { args?: { command?: string } }).args?.command ?? '') : null,
-      result: (output as { error?: unknown }).error ? 'error' : 'success',
-      metadata: { tool: input.tool, callId: input.callID },
-    };
-    if (input.tool === 'write') eventInput.eventType = 'file_created';
-    if (input.tool === 'edit' || input.tool === 'multiedit') eventInput.eventType = 'file_modified';
-    if ((output as { error?: unknown }).error) eventInput.eventType = 'failed_approach';
+      tool: input.tool,
+      callId: input.callID,
+      args: input.args,
+      title: output.title,
+      output: summarizeToolOutput(output.output),
+      metadata: output.metadata,
+    });
     await ctx.agentBookEvents.append(eventInput);
     await regenerateAgentBookFrontPage(ctx, projectId);
   } catch (agentBookError) {
@@ -151,6 +148,7 @@ async function captureAgentBookEvent(
 
 async function regenerateAgentBookFrontPage(ctx: PluginContext, projectId: string): Promise<void> {
   if (!ctx.agentBookState || !ctx.agentBookEvents || !ctx.agentBookRules || !ctx.agentBookSummary) return;
+  if (!ctx.directory) return;
   try {
     await ctx.agentBookSummary.maybeGenerate(projectId);
     const state = await ctx.agentBookState.project(projectId);
@@ -160,8 +158,7 @@ async function regenerateAgentBookFrontPage(ctx: PluginContext, projectId: strin
       ctx.agentBookEvents.getRecentEvents(projectId, 10),
     ]);
     const frontPage = generateFrontPage(state, latestSummary, rules, recentEvents);
-    const projectRoot = process.cwd();
-    writeFrontPageFile(frontPage.markdown, projectRoot);
+    writeFrontPageFile(frontPage.markdown, ctx.directory);
   } catch (regenError) {
     getLogger().debug(`AgentBook frontpage regen skipped: ${regenError instanceof Error ? regenError.message : String(regenError)}`);
   }

--- a/test/agentbook-tool-event.test.ts
+++ b/test/agentbook-tool-event.test.ts
@@ -1,0 +1,67 @@
+import { it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAgentBookToolEventInput } from '../dist/agentbook-tool-event.js';
+
+function build(overrides: Partial<Parameters<typeof buildAgentBookToolEventInput>[0]> = {}) {
+  return buildAgentBookToolEventInput({
+    projectId: 'test-project',
+    sessionId: 'ses_1',
+    tool: 'grep',
+    callId: 'call_1',
+    args: {},
+    title: 'Tool result',
+    output: 'completed',
+    metadata: {},
+    ...overrides,
+  });
+}
+
+it('records read tools as file reads with file evidence', () => {
+  const event = build({ tool: 'read', args: { filePath: 'src/index.ts' } });
+  assert.equal(event.eventType, 'file_read');
+  assert.deepEqual(event.files, ['src/index.ts']);
+});
+
+it('does not misclassify non-file tools as file modifications', () => {
+  const event = build({ tool: 'grep', args: { pattern: 'AgentBook' } });
+  assert.equal(event.eventType, 'note');
+  assert.deepEqual(event.files, []);
+});
+
+it('records write and edit tools with their actual file paths', () => {
+  const created = build({ tool: 'write', args: { path: 'src/new.ts' } });
+  const modified = build({ tool: 'apply_patch', args: { file: 'src/existing.ts' } });
+  assert.equal(created.eventType, 'file_created');
+  assert.deepEqual(created.files, ['src/new.ts']);
+  assert.equal(modified.eventType, 'file_modified');
+  assert.deepEqual(modified.files, ['src/existing.ts']);
+});
+
+it('uses host error metadata to classify failed approaches', () => {
+  const event = build({ metadata: { error: 'permission denied' } });
+  assert.equal(event.eventType, 'failed_approach');
+  assert.equal(event.result, 'error');
+  assert.equal(event.metadata?.error, 'permission denied');
+});
+
+it('treats non-zero command exits as failures and preserves the command', () => {
+  const event = build({
+    tool: 'bash',
+    args: { command: 'npm test' },
+    metadata: { exitCode: 1 },
+  });
+  assert.equal(event.eventType, 'failed_approach');
+  assert.equal(event.command, 'npm test');
+  assert.equal(event.result, 'error');
+});
+
+it('records successful commands without inventing file modifications', () => {
+  const event = build({
+    tool: 'bash',
+    args: { command: 'npm run build' },
+    metadata: { exitCode: 0 },
+  });
+  assert.equal(event.eventType, 'command_run');
+  assert.equal(event.command, 'npm run build');
+  assert.equal(event.result, 'success');
+});


### PR DESCRIPTION
## What changed

- classify AgentBook tool events by the actual tool instead of recording every non-bash call as `file_modified`
- detect failures from `output.metadata.error` and non-zero `exitCode`
- attach file-path evidence and command/result metadata to ledger events
- write `AGENTBOOK_STATE.md` to the plugin workspace (`ctx.directory`) rather than the process working directory
- add focused regression coverage for reads, writes, edits, commands, unknown tools, and failed executions

## Root cause

The merged hook used a duplicate `bash` comparison, defaulted all other tools to `file_modified`, inspected an error field that the host does not populate, and regenerated the front page relative to `process.cwd()`. That could corrupt the operational ledger and update the wrong workspace.

## Validation

- focused helper TypeScript compile and runtime smoke passed
- six focused regression tests added
- full repository CI is pending on this PR; the GitHub connector reported no status checks on the prior master commit
