### PR TITLE
fix(ci): repair failing master checks

### DIFF
--- a/.github/ci-probe.md
+++ b/.github/ci-probe.md
@@ -1,0 +1,3 @@
+# CI diagnostic probe
+
+Temporary branch-only marker used to reproduce the failing `master` checks through a pull-request-triggered workflow. It will be removed before merge.

--- a/.github/workflows/ci-source-snapshot.yml
+++ b/.github/workflows/ci-source-snapshot.yml
@@ -15,12 +15,12 @@ jobs:
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Build source archive
-        run: tar --exclude=.git -czf csm-source.tgz .
+        run: tar --exclude=.git -czf "$RUNNER_TEMP/csm-source.tgz" .
 
       - name: Upload source archive
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: csm-source-${{ github.sha }}
-          path: csm-source.tgz
+          path: ${{ runner.temp }}/csm-source.tgz
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/ci-source-snapshot.yml
+++ b/.github/workflows/ci-source-snapshot.yml
@@ -1,0 +1,26 @@
+name: CI Source Snapshot
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Build source archive
+        run: tar --exclude=.git -czf csm-source.tgz .
+
+      - name: Upload source archive
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: csm-source-${{ github.sha }}
+          path: csm-source.tgz
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
Superseded by #52, which is based on the latest `master` head and contains only the verified five-file repair. This diagnostic branch also contains temporary probe/snapshot artifacts and must not be merged.