### PR TITLE
fix(ci): resolve provider and cross-platform regressions

### DIFF
--- a/.github/ci-regression-probe.md
+++ b/.github/ci-regression-probe.md
@@ -1,3 +1,0 @@
-# CI regression probe
-
-Temporary branch-only marker used to reproduce the current `master` failures through pull-request-triggered workflows. It will be removed before merge.

--- a/.github/ci-regression-probe.md
+++ b/.github/ci-regression-probe.md
@@ -1,0 +1,3 @@
+# CI regression probe
+
+Temporary branch-only marker used to reproduce the current `master` failures through pull-request-triggered workflows. It will be removed before merge.

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,4 +1,4 @@
-﻿import type { PluginConfig } from './types.js';
+import type { PluginConfig } from './types.js';
 import { requestRemoteEmbedding } from './embedding-provider-client.js';
 import {
   averageEmbeddings,
@@ -58,21 +58,17 @@ export class EmbeddingGenerator {
     return results;
   }
 
-  private async generateChunk(chunk: EmbeddingChunk): Promise<number[]> {
+  private generateChunk(chunk: EmbeddingChunk): Promise<number[]> {
     if (this.provider === 'hash') {
-      return hashEmbedding(chunk.content, this.dimensions);
+      return Promise.resolve(hashEmbedding(chunk.content, this.dimensions));
     }
-    try {
-      return await requestRemoteEmbedding({
-        provider: this.provider,
-        model: this.config.embeddingModel,
-        dimensions: this.dimensions,
-        apiKey: this.config.embeddingApiKey,
-        apiUrl: this.config.embeddingApiUrl,
-      }, chunk.content);
-    } catch {
-      return hashEmbedding(chunk.content, this.dimensions);
-    }
+    return requestRemoteEmbedding({
+      provider: this.provider,
+      model: this.config.embeddingModel,
+      dimensions: this.dimensions,
+      apiKey: this.config.embeddingApiKey,
+      apiUrl: this.config.embeddingApiUrl,
+    }, chunk.content);
   }
 }
 

--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -140,6 +140,10 @@ export class Redactor {
     }
 
     try {
+      const trimmed = text.trim();
+      if (this.config.categories.path !== 'off' && looksLikeStandalonePath(trimmed)) {
+        return this.redactPath(text);
+      }
       return this.redactUnsafe(text);
     } catch {
       // Fail-closed: redact everything we safely can
@@ -416,6 +420,16 @@ function pathStyle(value: string): 'windows' | 'posix' {
 function isAbsolutePath(value: string): boolean {
   if (!value || /[\r\n"']/.test(value)) return false;
   return pathStyle(value) === 'windows' ? win32.isAbsolute(value) : posix.isAbsolute(value);
+}
+
+function looksLikeStandalonePath(value: string): boolean {
+  if (!isAbsolutePath(value) || /\s--?[A-Za-z0-9]/u.test(value)) return false;
+  const absolutePathStarts = value.match(
+    /(?:^|\s)(?:[A-Za-z]:[\\/]|\\\\|\/(?:home|Users|root|var|opt|etc|tmp|usr|mnt|srv|data|www|private|Volumes|Library|Applications)(?:\/|$))/gu,
+  );
+  if ((absolutePathStarts?.length ?? 0) > 1) return false;
+  if (/^[A-Za-z]:[\\/]/u.test(value) || value.startsWith('\\\\')) return true;
+  return /^\/(?:home|Users|root|var|opt|etc|tmp|usr|mnt|srv|data|www|private|Volumes|Library|Applications)(?:\/.+)+$/u.test(value);
 }
 
 /**

--- a/src/wiki-export-files.ts
+++ b/src/wiki-export-files.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { dirname, posix, win32 } from 'node:path';
 import { renderLogEntry, type LogEntry, type RenderedNote } from './wiki-note-renderer.js';
 import type { WikiExportManifest } from './wiki-export-types.js';
 
@@ -55,16 +55,38 @@ export function pruneOwnedFiles(outputDir: string, paths: string[]): number {
 }
 
 export function resolveOwnedPath(outputDir: string, manifestPath: string): string {
-  if (!manifestPath || isAbsolute(manifestPath)) {
+  const windowsRoot = isWindowsPath(outputDir)
+    || (!posix.isAbsolute(outputDir) && process.platform === 'win32');
+  const pathApi = windowsRoot ? win32 : posix;
+  const containsTraversal = manifestPath.split(/[\\/]/u).includes('..');
+
+  if (
+    !manifestPath
+    || manifestPath.includes('\0')
+    || containsTraversal
+    || /^[A-Za-z]:/u.test(manifestPath)
+    || win32.isAbsolute(manifestPath)
+    || posix.isAbsolute(manifestPath)
+  ) {
     throw new Error(`Unsafe wiki manifest path: ${manifestPath}`);
   }
-  const root = resolve(outputDir);
-  const candidate = resolve(root, manifestPath);
-  const fromRoot = relative(root, candidate);
-  if (!fromRoot || fromRoot.startsWith('..') || isAbsolute(fromRoot)) {
+
+  const root = pathApi.resolve(outputDir);
+  const candidate = pathApi.resolve(root, manifestPath);
+  const fromRoot = pathApi.relative(root, candidate);
+  if (
+    !fromRoot
+    || fromRoot === '..'
+    || fromRoot.startsWith(`..${pathApi.sep}`)
+    || pathApi.isAbsolute(fromRoot)
+  ) {
     throw new Error(`Unsafe wiki manifest path: ${manifestPath}`);
   }
   return candidate;
+}
+
+function isWindowsPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/u.test(value) || value.startsWith('\\\\');
 }
 
 export function appendExportLog(outputDir: string, entry: LogEntry): void {

--- a/test/backfill-recall-telemetry.test.ts
+++ b/test/backfill-recall-telemetry.test.ts
@@ -35,8 +35,8 @@ describe('Phase 19b — backfill and recall telemetry', () => {
     databaseUrl: buildTempDbUrl(BASE_DB_URL, tempDbName),
     databaseProvider: 'postgres',
     sqlitePath: '.data/csm-memory.db',
-    embeddingModel: 'nomic-embed-text',
-    embeddingApiUrl: process.env.OLLAMA_URL ?? 'http://localhost:11434',
+    embeddingModel: 'test-hash',
+    embeddingDimensions: 768,
   } as PluginConfig;
 
   let db: Database;

--- a/test/hybrid-search.test.ts
+++ b/test/hybrid-search.test.ts
@@ -60,8 +60,8 @@ async function cleanupDatabase(
     databaseUrl: databaseUrl(databaseName),
     databaseProvider: 'postgres',
     sqlitePath: '.data/csm-memory.db',
-    embeddingModel: 'nomic-embed-text',
-    embeddingApiUrl: process.env.OLLAMA_URL ?? 'http://localhost:11434',
+    embeddingModel: 'test-hash',
+    embeddingDimensions: 768,
   } as PluginConfig;
   let db: Database | undefined;
   let embeddings: EmbeddingGenerator;


### PR DESCRIPTION
## Root causes

- A CI-only unreachable Ollama dependency was “fixed” by silently switching configured providers to hash embeddings, violating the provider contract and changing vector semantics.
- Windows wiki-manifest paths were validated with the runner host’s POSIX path rules.
- Standalone unquoted absolute paths containing spaces were only partially redacted.

## Changes

- Restore explicit embedding-provider error and dimension failures; hash embeddings remain available only when selected by configuration.
- Make the two PostgreSQL integration suites use deterministic 768-dimensional hash embeddings instead of a live Ollama endpoint.
- Validate wiki manifest paths with the root’s path family and reject absolute, drive-relative, NUL, and traversal inputs across both separator styles.
- Route unambiguous standalone absolute paths through schema-aware whole-path redaction while preserving commands and multiple-path strings.

## Verification

- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run lint:src` — 0 errors, 7 baseline warnings
- Focused correction, redactor, embedding-provider, migration-artifact, and supply-chain tests — passed
- GitHub Actions PostgreSQL 14 matrix — passed, including full tests and backup/restore drill
- GitHub Actions PostgreSQL 16 matrix — passed, including full tests and backup/restore drill
- Supply-chain audit, license policy, SBOM, full-history secret scan, and dependency review — passed