### PR TITLE
Potential fix for code scanning alert no. 13: Inefficient regular expression

### DIFF
--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -106,7 +106,7 @@ const URL_QUERY_SECRET_PATTERN = /([?&](?:api[_-]?key|token|secret|password|acce
 // Absolute filesystem paths (Windows + POSIX)
 const QUOTED_WIN_PATH_PATTERN = /(["'])(?:[A-Za-z]:[\\/]|\\\\[^\\/:*?"'<>|\r\n]+[\\/][^\\/:*?"'<>|\r\n]+[\\/])[^"'<>|\r\n]+\1/g;
 const WIN_PATH_PATTERN = /(?:[A-Za-z]:[\\/](?:[^\s\\/:*?"<>|]+(?: (?![A-Za-z]:)[^\s\\/:*?"<>|]+)*[\\/])*[^\s\\/:*?"<>|]+(?: (?![A-Za-z]:)[^\s\\/:*?"<>|]+)*|\\\\[^\s\\/:*?"<>|]+[\\/][^\s\\/:*?"<>|]+(?:[\\/][^\s\\/:*?"<>|]+)*)/g;
-const QUOTED_POSIX_PATH_PATTERN = /(["'])\/(?:home|Users|root|var|opt|etc|tmp|usr|mnt|srv|data|www|private|Volumes|Library|Applications)(?:\/[^"'\r\n]+)+\1/g;
+const QUOTED_POSIX_PATH_PATTERN = /(["'])\/(?:home|Users|root|var|opt|etc|tmp|usr|mnt|srv|data|www|private|Volumes|Library|Applications)(?:\/[^\/"'\r\n]+)+\1/g;
 const POSIX_PATH_PATTERN = /\/(?:home|Users|root|var|opt|etc|tmp|usr|mnt|srv|data|www|private|Volumes|Library|Applications)(?:\/[^\s:*?"<>|]+(?: [^\s:*?"<>|]+)*)+/g;
 
 // ── Redactor class ────────────────────────────────────────────────────


### PR DESCRIPTION
Potential fix for [https://github.com/NovasPlace/CSM/security/code-scanning/13](https://github.com/NovasPlace/CSM/security/code-scanning/13)

The best fix is to remove nested/overlapping repetition ambiguity in `QUOTED_POSIX_PATH_PATTERN` by ensuring each repeated unit is a single path segment that cannot include `/`.  
Concretely, in `src/redactor.ts` line 109 region, replace:

- `(?:\/[^"'\r\n]+)+`

with a safer equivalent:

- `(?:\/[^\/"'\r\n]+)+`

This preserves functionality (quoted absolute POSIX-like paths under the listed roots) while preventing the inner segment matcher from consuming `/`, eliminating the exponential backtracking shape CodeQL reported. No new methods, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
