### PR TITLE
Potential fix for code scanning alert no. 11: Shell command built from environment values

### DIFF
--- a/scripts/release-package-stage.mjs
+++ b/scripts/release-package-stage.mjs
@@ -46,10 +46,6 @@ function npmPackArgs() {
   return args;
 }
 
-function quoteWindowsArg(value) {
-  return /[\s"]/u.test(value) ? `"${value.replaceAll('"', '\\"')}"` : value;
-}
-
 try {
   mkdirSync(staging, { recursive: true });
   const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
@@ -62,12 +58,7 @@ try {
   );
 
   const packArgs = npmPackArgs();
-  const windows = process.platform === 'win32';
-  const command = windows ? (process.env.ComSpec ?? 'cmd.exe') : 'npm';
-  const args = windows
-    ? ['/d', '/s', '/c', `npm.cmd ${packArgs.map(quoteWindowsArg).join(' ')}`]
-    : packArgs;
-  const result = spawnSync(command, args, {
+  const result = spawnSync('npm', packArgs, {
     cwd: staging,
     encoding: 'utf8',
     timeout: 120_000,


### PR DESCRIPTION
Potential fix for [https://github.com/NovasPlace/CSM/security/code-scanning/11](https://github.com/NovasPlace/CSM/security/code-scanning/11)

The best fix is to stop invoking `cmd.exe /c` with a constructed command string and instead execute `npm` directly with argument-array passing on all platforms. This avoids shell interpretation and removes the injection/misparsing class completely while preserving behavior.

In `scripts/release-package-stage.mjs`, update the execution block around lines 64–70:
- Remove Windows-specific shell command assembly (`ComSpec`, `cmd /c`, `quoteWindowsArg` usage).
- Call `spawnSync` with a fixed executable (`npm`) and `packArgs` directly.
- Keep existing `cwd`, `env`, timeout, and output handling unchanged.

Also remove the now-unused helper `quoteWindowsArg` to keep the file clean and avoid dead code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
